### PR TITLE
fix: patch websocket-driver CVE-2026-54466 (surgical upgrade)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "http-proxy": "^1.18.1",
     "ini": "^1.3.8",
     "minimist": "^1.2.8",
-    "semver": "^7.6.0"
+    "semver": "^7.6.0",
+    "websocket-driver": "^0.7.5"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5478,10 +5478,10 @@ http-errors@~1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
-"http-parser-js@>=0.4.0 <0.4.11":
-  version "0.4.10"
-  resolved "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz"
-  integrity sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=
+http-parser-js@>=0.5.1:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.10.tgz#b3277bd6d7ed5588e20ea73bf724fcbe44609075"
+  integrity sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==
 
 http-proxy-middleware@0.19.1:
   version "0.19.1"
@@ -11128,12 +11128,12 @@ webpack@4.42.0:
     watchpack "^1.6.0"
     webpack-sources "^1.4.1"
 
-websocket-driver@>=0.5.1:
-  version "0.7.3"
-  resolved "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz"
-  integrity sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==
+websocket-driver@>=0.5.1, websocket-driver@^0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.5.tgz#569d22764ab21f2de20af0e74b411e8ae5a0fa46"
+  integrity sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==
   dependencies:
-    http-parser-js ">=0.4.0 <0.4.11"
+    http-parser-js ">=0.5.1"
     safe-buffer ">=5.1.0"
     websocket-extensions ">=0.1.1"
 


### PR DESCRIPTION
Transitive dev dependency via react-scripts webpack-dev-server. Pin to 0.7.5 via yarn resolutions to fix message corruption vuln from protocol length header abuse.